### PR TITLE
Removing demo link

### DIFF
--- a/config.json
+++ b/config.json
@@ -23,11 +23,6 @@
             "title": "Visit the API Insights Site",
             "content": "https://developer.cisco.com/site/api-insights/",
             "type": "url"
-          },
-          {
-            "title": "Try a Demo of API Insights",
-            "content": "https://developer.cisco.com/api-insights-demo",
-            "type": "url"
           }
         ]
     },


### PR DESCRIPTION
Removing the link to the demo dashboard at https://developer.cisco.com/api-insights-demo/services per Neelesh's request.